### PR TITLE
added PokiSDK.openExternalLink(url)

### DIFF
--- a/poki-sdk/api/poki-sdk.script_api
+++ b/poki-sdk/api/poki-sdk.script_api
@@ -128,6 +128,22 @@
 
 #*****************************************************************************************************
 
+  - name: open_external_link
+    type: function
+
+    parameters:
+    - name: url
+      type: string
+
+  - name: openExternalLink
+    type: function
+
+    parameters:
+    - name: url
+      type: string
+
+#*****************************************************************************************************
+
   - name: COMMERCIAL_BREAK_SUCCESS
     type: number
   - name: COMMERCIAL_BREAK_START

--- a/poki-sdk/lib/web/lib_pokisdk.js
+++ b/poki-sdk/lib/web/lib_pokisdk.js
@@ -115,6 +115,10 @@ var LibPokiSdk = {
     PokiSdkJs_MovePill: function(topPercent, topPx) {
         PokiSDK.movePill(topPercent, topPx);
     },
+
+    PokiSdkJs_OpenExternalLink: function(url) {
+        PokiSDK.openExternalLink(UTF8ToString(url));
+    },
 }
 
 autoAddDeps(LibPokiSdk, '$PokiSdk');

--- a/poki-sdk/src/pokisdk.cpp
+++ b/poki-sdk/src/pokisdk.cpp
@@ -334,7 +334,6 @@ static const luaL_reg Module_methods[] =
     {"measure", PokiSdk_Measure},
     {"move_pill", PokiSdk_MovePill},
     {"open_external_link", PokiSdk_OpenExternalLink},
-    {"openExternalLink", PokiSdk_OpenExternalLink},
     {0, 0}
 };
 

--- a/poki-sdk/src/pokisdk.cpp
+++ b/poki-sdk/src/pokisdk.cpp
@@ -53,6 +53,7 @@ extern "C" {
     void PokiSdkJs_Measure(const char* category, const char* what, const char* action);
 
     void PokiSdkJs_MovePill(double topPercent, double topPx);
+    void PokiSdkJs_OpenExternalLink(const char* url);
 }
 
 static dmScript::LuaCallbackInfo* pokiSdk_Callback = 0x0;
@@ -310,6 +311,14 @@ static int PokiSdk_MovePill(lua_State* L)
     return 0;
 }
 
+static int PokiSdk_OpenExternalLink(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 0);
+    const char* url = luaL_checkstring(L, 1);
+    PokiSdkJs_OpenExternalLink(url);
+    return 0;
+}
+
 // Functions exposed to Lua
 static const luaL_reg Module_methods[] =
 {
@@ -324,6 +333,8 @@ static const luaL_reg Module_methods[] =
     {"get_url_param", PokiSdk_GetURLParam},
     {"measure", PokiSdk_Measure},
     {"move_pill", PokiSdk_MovePill},
+    {"open_external_link", PokiSdk_OpenExternalLink},
+    {"openExternalLink", PokiSdk_OpenExternalLink},
     {0, 0}
 };
 


### PR DESCRIPTION
Today during the QA review, the Poki team asked to wrap all external links that open in their own interface.

<img width="379" height="174" alt="изображение" src="https://github.com/user-attachments/assets/596cb941-0c1b-492a-9855-a2f7b32e51ef" />

It's not yet listed in the official documentation, but QA no longer allows links without this wrapper.
So, I've added an implementation of this function to the extension.

On Poki it looks like this:
<img width="704" height="401" alt="изображение" src="https://github.com/user-attachments/assets/8e436612-1745-421a-b5ee-f4bf95f8fb1a" />

