### PR TITLE
Restrict Poki builds to `wasm-web`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -187,7 +187,7 @@ Use `poki_sdk.login()` only in response to a user action that requires an accoun
 
 ## Example
 
-[Refer to the example project](https://github.com/defold/extension-poki-sdk/blob/master/main/poki-sdk.gui_script) to see a complete example of how the intergation works.
+[Refer to the example project](https://github.com/defold/extension-poki-sdk/blob/main/example/poki-sdk.gui_script) to see a complete example of how the integration works.
 
 
 ## Source code
@@ -213,4 +213,5 @@ poki_sdk.move_pill(topPercent, topPx) -- in JS it's PokiSDK.movePill(topPercent,
 poki_sdk.get_user(callback) -- in JS it's PokiSDK.getUser().then(user => {})
 poki_sdk.get_token(callback) -- in JS it's PokiSDK.getToken().then(token => {})
 poki_sdk.login(callback) -- in JS it's PokiSDK.login().then(() => {})
+poki_sdk.open_external_link(url) -- in JS it's PokiSDK.openExternalLink(url)
 ```

--- a/example/poki-sdk.gui_script
+++ b/example/poki-sdk.gui_script
@@ -73,9 +73,11 @@ end
 
 local function on_commercial_break_finished(self, status)
 	if status == poki_sdk.COMMERCIAL_BREAK_START then
+		print("COMMERCIAL_BREAK_START")
 		gui.set_text(gui.get_node("success"), "Commercial started")
 	elseif status == poki_sdk.COMMERCIAL_BREAK_SUCCESS then
 		-- continue game
+		print("COMMERCIAL_BREAK_SUCCESS")
 		gui.set_text(gui.get_node("success"), "Commercial finished")
 	end
 end

--- a/poki-sdk/api/poki-sdk.script_api
+++ b/poki-sdk/api/poki-sdk.script_api
@@ -100,7 +100,7 @@
     
     return:
     - name: value
-      type: string
+      type: string|nil
 
 #*****************************************************************************************************
 
@@ -181,7 +181,7 @@
           desc: The calling script instance
         - name: success
           type: boolean
-          desc: `true` if the login promise resolved, otherwise `false`.
+          desc: "`true` if the login promise resolved, otherwise `false`."
         - name: error
           type: string
           desc: The rejection message on failure, or `nil` on success.

--- a/poki-sdk/editor/poki.editor_script
+++ b/poki-sdk/editor/poki.editor_script
@@ -18,8 +18,8 @@ local function urlencode(str)
 end
 
 local function poki_errors(config)
-    if not next(config.architectures) then
-        return "At least one architecture must be selected."
+    if not config.architectures["wasm-web"] then
+        return "WebAssembly (wasm) architecture must be selected."
     end
 end
 
@@ -28,7 +28,6 @@ local poki_bundle_dialog = editor.ui.component(function(props)
     local architecture_error = poki_errors(config)
     return editor.bundle.dialog("Bundle and Submit for QA", config, nil, architecture_error, {
         editor.bundle.grid_row("Architectures", {
-            editor.bundle.set_element_check_box(config, set_config, "architectures", "js-web", "asm.js", architecture_error),
             editor.bundle.set_element_check_box(config, set_config, "architectures", "wasm-web", "WebAssembly (wasm)", architecture_error)
         }),
         editor.bundle.common_variant_grid_row(config, set_config),
@@ -41,12 +40,9 @@ local function bundle_poki(show_dialog)
     local title = project_title()
 
     local config = editor.bundle.config(show_dialog, "bundle.poki", poki_bundle_dialog, poki_errors)
-    local js = config.architectures["js-web"]
-    local wasm = config.architectures["wasm-web"]
-    local output_subdir = (js and wasm and "universal-web") or (js and "js-web") or "wasm-web"
+    local output_subdir = "wasm-web"
     local output_directory = editor.bundle.output_directory(show_dialog, output_subdir)
-    local architectures = (js and wasm and "js-web,wasm-web") or (js and "js-web") or "wasm-web"
-    editor.bundle.create(config, output_directory, { platform = "js-web", architectures = architectures })
+    editor.bundle.create(config, output_directory, { platform = "wasm-web", architectures = "wasm-web" })
 
     -- zip bundle output directory
     zip.pack(POKI_ZIP, { 
@@ -90,7 +86,7 @@ local function build_poki_html5()
         archive = true,
         texture_compression = editor.prefs.get("build.texture-compression"),
         bundle_output = launch_dir,
-        platform = "js-web",
+        platform = "wasm-web",
         verbose = true,
         variant = "debug"
     }
@@ -134,7 +130,7 @@ function M.get_prefs_schema()
     return {
         ["bundle.poki"] = editor.bundle.config_schema(editor.bundle.common_variant_schema, {
             architectures = editor.prefs.schema.set({
-                item = editor.prefs.schema.enum({values = {"js-web", "wasm-web"}}),
+                item = editor.prefs.schema.enum({values = {"wasm-web"}}),
                 default = {["wasm-web"] = true}
             })
         }),


### PR DESCRIPTION
Restrict Poki editor bundle/build flow to wasm-web.
Update API docs for nullable URL params, login, and open_external_link.
Fix example doc link/typo and add commercial-break logging in the sample.
